### PR TITLE
fix: allow peer dependency with react 17 and 18 without warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^3.8.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
+    "react": "^16 || ^17 || ^18",
     "react-native": "*"
   }
 }


### PR DESCRIPTION
Including this in a repo with a more recent version of React works, but issues this warning. Would you mind publishing a version with this, so that the logs are just slightly cleaner? ❤️ 
```
warning " > react-native-draggable-grid@2.1.5" has incorrect peer dependency "react@^16.0.0".
```